### PR TITLE
Cumulative execution of user code

### DIFF
--- a/src/components/cell-list/cell-list.css
+++ b/src/components/cell-list/cell-list.css
@@ -1,0 +1,7 @@
+.cell-list {
+  margin: 12px 30px 37vh;
+}
+
+.react-draggable-transparent-selection .cell-list {
+  margin-bottom: 100vh;
+}

--- a/src/components/cell-list/cell-list.tsx
+++ b/src/components/cell-list/cell-list.tsx
@@ -1,3 +1,4 @@
+import './cell-list.css'
 import { Fragment } from 'react'
 import { useTypedSelector } from '../../hooks'
 import CellListItem from './cell-list-item'
@@ -16,7 +17,7 @@ const CellList: React.FC = () => {
   ))
 
   return (
-    <div>
+    <div className='cell-list'>
       <AddCell forceVisible={cells.length === 0} prevCellId={null} />
       {renderedCells}
     </div>

--- a/src/components/code-cell/code-cell.tsx
+++ b/src/components/code-cell/code-cell.tsx
@@ -11,24 +11,39 @@ interface CodeCellProps {
 const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
   const { updateCell, createBundle } = useActions()
   const bundle = useTypedSelector(state => state.bundles[cell.id])
+  const cumulativeCode = useTypedSelector(state => {
+    const { data, order } = state.cells
+    const orderedCells = order.map(id => data[id])
+
+    const cumulativeCode = []
+    for (let c of orderedCells) {
+      if (c.type === 'code') {
+        cumulativeCode.push(c.content)
+      }
+      if (c.id === cell.id) {
+        break
+      }
+    }
+    return cumulativeCode
+  })
 
   // auto-bundle user code after 0.8s
   // if there is no bundle, immediately create it
   useEffect(() => {
     if (!bundle) {
-      createBundle(cell.id, cell.content)
+      createBundle(cell.id, cumulativeCode.join('\n'))
       return
     }
 
     const timer = setTimeout(async () => {
-      createBundle(cell.id, cell.content)
+      createBundle(cell.id, cumulativeCode.join('\n'))
     }, 800)
 
     return () => {
       clearTimeout(timer)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cell.content, cell.id, createBundle])
+  }, [cumulativeCode.join('\n'), cell.id, createBundle])
 
   return (
     <Resizable direction='vertical'>

--- a/src/components/code-cell/code-cell.tsx
+++ b/src/components/code-cell/code-cell.tsx
@@ -11,11 +11,21 @@ interface CodeCellProps {
 const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
   const { updateCell, createBundle } = useActions()
   const bundle = useTypedSelector(state => state.bundles[cell.id])
+
   const cumulativeCode = useTypedSelector(state => {
     const { data, order } = state.cells
     const orderedCells = order.map(id => data[id])
-
-    const cumulativeCode = []
+    const cumulativeCode = [
+      `
+        const show = (value) => {
+          if (typeof value === 'object') {
+            document.querySelector('#root).innerHTML = JSON.stringify(value)
+          } else {
+            document.querySelector('#root).innerHTML = value
+          }
+        }
+      `,
+    ]
     for (let c of orderedCells) {
       if (c.type === 'code') {
         cumulativeCode.push(c.content)

--- a/src/components/code-cell/code-cell.tsx
+++ b/src/components/code-cell/code-cell.tsx
@@ -17,11 +17,19 @@ const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
     const orderedCells = order.map(id => data[id])
     const cumulativeCode = [
       `
-        const show = (value) => {
-          if (typeof value === 'object') {
-            document.querySelector('#root).innerHTML = JSON.stringify(value)
+        import _React from 'react'
+        import _ReactDOM from 'react-dom'
+        
+        var show = (value) => {
+          const root = document.querySelector('#root')
+          if (typeof  value === 'object') {
+            if (value.$$typeof && value.props) {
+              _ReactDOM.render(value, root)
+            } else {
+              root.innerHTML = JSON.stringify(value)
+            }
           } else {
-            document.querySelector('#root).innerHTML = value
+            root.innerHTML = value
           }
         }
       `,

--- a/src/components/code-cell/code-cell.tsx
+++ b/src/components/code-cell/code-cell.tsx
@@ -2,7 +2,7 @@ import './code-cell.css'
 import { useEffect } from 'react'
 import { CodeEditor, Preview, Resizable } from '..'
 import { Cell } from '../../state'
-import { useActions, useTypedSelector } from '../../hooks'
+import { useActions, useCumulativeCode, useTypedSelector } from '../../hooks'
 
 interface CodeCellProps {
   cell: Cell
@@ -11,66 +11,25 @@ interface CodeCellProps {
 const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
   const { updateCell, createBundle } = useActions()
   const bundle = useTypedSelector(state => state.bundles[cell.id])
-
-  const cumulativeCode = useTypedSelector(state => {
-    const { data, order } = state.cells
-    const orderedCells = order.map(id => data[id])
-
-    const showFn = `
-    import _React from 'react'
-    import _ReactDOM from 'react-dom'
-
-    var show = (value) => {
-      const root = document.querySelector('#root')
-      
-      if (typeof  value === 'object') {
-        if (value.$$typeof && value.props) {
-          _ReactDOM.render(value, root)
-        } else {
-          root.innerHTML = JSON.stringify(value)
-        }
-      } else {
-        root.innerHTML = value
-      }
-    }
-  `
-
-    const showFnNoOp = 'var show = () => {}'
-
-    const cumulativeCode = []
-    for (let c of orderedCells) {
-      if (c.type === 'code') {
-        if (c.id === cell.id) {
-          cumulativeCode.push(showFn)
-        } else {
-          cumulativeCode.push(showFnNoOp)
-        }
-        cumulativeCode.push(c.content)
-      }
-      if (c.id === cell.id) {
-        break
-      }
-    }
-    return cumulativeCode
-  })
+  const cumulativeCode = useCumulativeCode(cell.id)
 
   // auto-bundle user code after 0.8s
   // if there is no bundle, immediately create it
   useEffect(() => {
     if (!bundle) {
-      createBundle(cell.id, cumulativeCode.join('\n'))
+      createBundle(cell.id, cumulativeCode)
       return
     }
 
     const timer = setTimeout(async () => {
-      createBundle(cell.id, cumulativeCode.join('\n'))
+      createBundle(cell.id, cumulativeCode)
     }, 800)
 
     return () => {
       clearTimeout(timer)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cumulativeCode.join('\n'), cell.id, createBundle])
+  }, [cumulativeCode, cell.id, createBundle])
 
   return (
     <Resizable direction='vertical'>

--- a/src/components/code-cell/code-cell.tsx
+++ b/src/components/code-cell/code-cell.tsx
@@ -15,27 +15,36 @@ const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
   const cumulativeCode = useTypedSelector(state => {
     const { data, order } = state.cells
     const orderedCells = order.map(id => data[id])
-    const cumulativeCode = [
-      `
-        import _React from 'react'
-        import _ReactDOM from 'react-dom'
-        
-        var show = (value) => {
-          const root = document.querySelector('#root')
-          if (typeof  value === 'object') {
-            if (value.$$typeof && value.props) {
-              _ReactDOM.render(value, root)
-            } else {
-              root.innerHTML = JSON.stringify(value)
-            }
-          } else {
-            root.innerHTML = value
-          }
+
+    const showFn = `
+    import _React from 'react'
+    import _ReactDOM from 'react-dom'
+
+    var show = (value) => {
+      const root = document.querySelector('#root')
+      
+      if (typeof  value === 'object') {
+        if (value.$$typeof && value.props) {
+          _ReactDOM.render(value, root)
+        } else {
+          root.innerHTML = JSON.stringify(value)
         }
-      `,
-    ]
+      } else {
+        root.innerHTML = value
+      }
+    }
+  `
+
+    const showFnNoOp = 'var show = () => {}'
+
+    const cumulativeCode = []
     for (let c of orderedCells) {
       if (c.type === 'code') {
+        if (c.id === cell.id) {
+          cumulativeCode.push(showFn)
+        } else {
+          cumulativeCode.push(showFnNoOp)
+        }
         cumulativeCode.push(c.content)
       }
       if (c.id === cell.id) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-actions'
 export * from './use-typed-selector'
+export * from './use-cumulative-code'

--- a/src/hooks/use-cumulative-code.ts
+++ b/src/hooks/use-cumulative-code.ts
@@ -1,0 +1,45 @@
+import { useTypedSelector } from './use-typed-selector'
+
+export const useCumulativeCode = (cellId: string) => {
+  return useTypedSelector(state => {
+    const { data, order } = state.cells
+    const orderedCells = order.map(id => data[id])
+
+    const showFn = `
+    import _React from 'react'
+    import _ReactDOM from 'react-dom'
+
+    var show = (value) => {
+      const root = document.querySelector('#root')
+      
+      if (typeof  value === 'object') {
+        if (value.$$typeof && value.props) {
+          _ReactDOM.render(value, root)
+        } else {
+          root.innerHTML = JSON.stringify(value)
+        }
+      } else {
+        root.innerHTML = value
+      }
+    }
+  `
+
+    const showFnNoOp = 'var show = () => {}'
+
+    const cumulativeCode = []
+    for (let c of orderedCells) {
+      if (c.type === 'code') {
+        if (c.id === cellId) {
+          cumulativeCode.push(showFn)
+        } else {
+          cumulativeCode.push(showFnNoOp)
+        }
+        cumulativeCode.push(c.content)
+      }
+      if (c.id === cellId) {
+        break
+      }
+    }
+    return cumulativeCode
+  }).join('\n')
+}

--- a/src/state/reducers/bundlesReducer.ts
+++ b/src/state/reducers/bundlesReducer.ts
@@ -36,6 +36,7 @@ const reducer = produce(
         return state
     }
   },
+  // initialState as 2nd arg is crucial, do not remove!
   initialState
 )
 


### PR DESCRIPTION
#### Cumulative Code: each new code cell 'remembers' declared variables, functions, etc from previous cells
- implements functionality to bundle code from current cell and all previous cells (if any) when bundling
- creates hook to cumulatively execute code
- implements built-in `show()` function in hook to display rendered code in preview window
    - replaces `document.querySelector('#root').innerHTML` et al
    - includes functionality to display complex values (e.g. objects)
    - includes functionality to display `jsx` elements & `React` components
    - overrides default `esBuild` behaviour to prevent conflict between user imports and `show()`
    - implements no-op to only execute `show()` in preview window of cell in which it was invoked (i.e. not cumulatively)
- adds page margins and prevents edge snaps when last editor on page is dramatically resized